### PR TITLE
Speedup rendering

### DIFF
--- a/src/app/config-template.py
+++ b/src/app/config-template.py
@@ -56,3 +56,6 @@ START_URI = urljoin(DEFAULT_BASE,START_LOCAL_NAME)
 
 # Set query results limit because otherwise your browser might crash.
 QUERY_RESULTS_LIMIT = 1000
+
+# The port via which to run brwsr
+PORT = 5000

--- a/src/app/static/brwsr.js
+++ b/src/app/static/brwsr.js
@@ -5,11 +5,10 @@ $( document ).ready(function() {
       var element_text = $(this).text();
       
       if (element_text && element_text.substr(0,4) == 'http') {
-        $.get('http://preflabel.org/api/v1/label/'+encodeURIComponent($(element).text())+"?callback=?", function(data){
-          updateLabel(data,element);
-        }).fail(function(){
-          updateLabel(element_text,element);
-        });
+            updateLabel(element_text,element);
+            $.get('http://preflabel.org/api/v1/label/'+encodeURIComponent($(element).text())+"?callback=?", function(data){
+              updateLabel(data,element);
+            });
       } 
     });
     

--- a/src/run.py
+++ b/src/run.py
@@ -1,4 +1,3 @@
-from app import app
-
+from app import app, config
 if __name__ == "__main__":
-    app.run(host="0.0.0.0")
+    app.run(host="0.0.0.0", port=(config.PORT if hasattr(config, 'PORT') else 5000))


### PR DESCRIPTION
If preflabel is slow (or down, as it is right now), the 'onFail' function takes a long time to execute. 
Now, we draw this part of the function before the preflabel ajax request, and redraw it when ajax call succeeds. Can be a bit more efficient though
