### PR TITLE
log.debug call was referring to an undefined variable

### DIFF
--- a/src/app/client.py
+++ b/src/app/client.py
@@ -32,8 +32,7 @@ def visit(url, format='html'):
             break
     if not sparql:
         sparql = SPARQLWrapper(SPARQL_ENDPOINT)
-
-    log.debug("Will be using {}".format(endpoint))
+        log.debug("Will be using {}".format(SPARQL_ENDPOINT))
 
     for key, value in CUSTOM_PARAMETERS.items():
         sparql.addParameter(key, value)


### PR DESCRIPTION
When SPARQL_ENDPOINT_MAPPING is empty application was failing with the following error:

File "...../brwsr/src/app/client.py", line 36, in visit log.debug("Will be using {}".format(endpoint)) UnboundLocalError: local variable 'endpoint' referenced before assignment
