### PR TITLE
added safety check for javascript injections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ include/
 pip-selfcheck.json
 *.pyc
 src/app/config.py
+.DS_Store

--- a/src/app/views.py
+++ b/src/app/views.py
@@ -165,8 +165,13 @@ def browse():
 
         try:
             if mimetype in ['text/html', 'application/xhtml_xml', '*/*']:
-                results = visit(uri, format='html', external=True)
+                try:
+                    results = visit(uri, format='html', external=True)
+                except: #when the uri is a javascript injection (or any other illegal string) this will fail and the uri shouldn't be send to the response
+                    return render_template('resource.html', local_resource='http://bla', resource="error in sparql query", results=[], local=LOCAL_STORE, preflabel=PREFLABEL_SERVICE)
                 local_results = localize_results(results)
+                if local_results == []: #when there are no results the uri might be a javascript injection and the uri shouldn't be send to the response
+                    uri = "unknown uri"
                 return render_template('resource.html', local_resource='http://bla', resource=uri, results=local_results, local=LOCAL_STORE, preflabel=PREFLABEL_SERVICE)
             elif mimetype in ['application/json']:
                 response = make_response(visit(uri, format='jsonld', external=True), 200)


### PR DESCRIPTION
It was possible to inject javascript as the "uri" that is used by the `/browse` function, the added code determines if the uri received in `/browse` receives any results before it is send to the template (if not it is not used in the template).